### PR TITLE
CameraService: Bump up the maximum number of cameras

### DIFF
--- a/services/camera/libcameraservice/CameraService.h
+++ b/services/camera/libcameraservice/CameraService.h
@@ -38,7 +38,7 @@
 #include <camera/ICameraServiceListener.h>
 
 /* This needs to be increased if we can have more cameras */
-#define MAX_CAMERAS 2
+#define MAX_CAMERAS 4
 
 namespace android {
 


### PR DESCRIPTION
 Currently at maximum only two cameras will be
 advertised by CameraService layer. If we need
 to support multiple CameraHal implementations
 (HAL 1.0 vs. HAL 3.0) at the same time, then
 this limit needs to be updated.

Change-Id: Idc9d72da2eecfc2080dcc3f362d3939cebbd17eb