### PR TITLE
libmedia: restrict nuplayer from using track offload

### DIFF
--- a/media/libmedia/AudioTrack.cpp
+++ b/media/libmedia/AudioTrack.cpp
@@ -269,8 +269,7 @@ bool AudioTrack::canOffloadTrack(
        // Track offload only if the following criterion
        // 1. Track offload info structure should NOT have been provided
        // 2. Format is 16 bit
-       // 3. Track is NOT fast track (to prevent tones, and low latency from
-       //     being offloaded
+       // 3. Track should not have any flags other NONE
        // 4. Client uses write interface to provide data
 
 
@@ -279,7 +278,7 @@ bool AudioTrack::canOffloadTrack(
         if (!offloadInfo &&
              (format == AUDIO_FORMAT_PCM_16_BIT) &&
              (streamType == AUDIO_STREAM_MUSIC) &&
-             (!(flags & AUDIO_OUTPUT_FLAG_FAST)) &&
+             (flags == AUDIO_OUTPUT_FLAG_NONE) &&
              (transferType != TRANSFER_CALLBACK))
         {
 

--- a/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
@@ -1618,6 +1618,11 @@ status_t NuPlayer::Renderer::onOpenAudioSink(
         uint32_t pcmFlags = flags;
         pcmFlags &= ~AUDIO_OUTPUT_FLAG_COMPRESS_OFFLOAD;
 
+        if (ExtendedUtils::isTrackOffloadEnabled()) {
+            ALOGV("TrackOffload: Enabled, setting deep buffer flag");
+            pcmFlags |= AUDIO_OUTPUT_FLAG_DEEP_BUFFER;
+        }
+
         const PcmInfo info = {
                 (audio_channel_mask_t)channelMask,
                 (audio_output_flags_t)pcmFlags,

--- a/media/libstagefright/ExtendedUtils.cpp
+++ b/media/libstagefright/ExtendedUtils.cpp
@@ -1045,6 +1045,19 @@ bool ExtendedUtils::is16bitPCMOffloadEnabled() {
         return false;
 }
 
+bool ExtendedUtils::isTrackOffloadEnabled() {
+    char propTrackOffload[PROPERTY_VALUE_MAX] = {0};
+
+    //track offload will work only if 16 bit PCM offloading is enabled
+    if (is16bitPCMOffloadEnabled()) {
+        property_get("audio.offload.track.enabled", propTrackOffload, "0");
+        if (!strncmp(propTrackOffload, "true", 4) || atoi(propTrackOffload))
+            return true;
+    }
+
+    return false;
+}
+
 bool ExtendedUtils::isRAWFormat(const sp<MetaData> &meta) {
     const char *mime = {0};
     if (meta == NULL) {
@@ -2145,6 +2158,10 @@ bool ExtendedUtils::is24bitPCMOffloadEnabled() {
 }
 
 bool ExtendedUtils::is16bitPCMOffloadEnabled() {
+    return false;
+}
+
+bool ExtendedUtils::isTrackOffloadEnabled() {
     return false;
 }
 

--- a/media/libstagefright/include/ExtendedUtils.h
+++ b/media/libstagefright/include/ExtendedUtils.h
@@ -218,6 +218,7 @@ struct ExtendedUtils {
 
     static bool is24bitPCMOffloadEnabled();
     static bool is16bitPCMOffloadEnabled();
+    static bool isTrackOffloadEnabled();
     static bool isRAWFormat(const sp<MetaData> &meta);
     static bool isRAWFormat(const sp<AMessage> &format);
     static int32_t getPcmSampleBits(const sp<MetaData> &meta);


### PR DESCRIPTION
NuPlayer sets _NONE flags in the default path, this
leads to nuplayer using audio track offload, even
though the decision was to use deep buffer.
Restrict this behavior only to platforms
that have track offload enabled

Change-Id: I6191362850014f14c0e10da5bd30be86527fad34
CRs-Fixed: 833895