### PR TITLE
Revert "Enable -Os back to audioflinger"

### DIFF
--- a/services/audioflinger/Android.mk
+++ b/services/audioflinger/Android.mk
@@ -93,8 +93,6 @@ endif
 endif
 #QTI Resampler
 
-LOCAL_CFLAGS += -Os
-
 LOCAL_MODULE:= libaudioflinger
 LOCAL_32_BIT_ONLY := true
 


### PR DESCRIPTION
This reverts commit 2c950c21a0913c42eaf13a23cb7ac969c3b28ad3.