### PR TITLE
audiopolicy: Make sense of concurrency properties

### DIFF
--- a/services/audiopolicy/AudioPolicyManager.cpp
+++ b/services/audiopolicy/AudioPolicyManager.cpp
@@ -890,21 +890,9 @@ void AudioPolicyManager::setPhoneState(audio_mode_t state)
 
 #ifdef VOICE_CONCURRENCY
     int voice_call_state = 0;
-    char propValue[PROPERTY_VALUE_MAX];
-    bool prop_playback_enabled = false, prop_rec_enabled=false, prop_voip_enabled = false;
-
-    if(property_get("voice.playback.conc.disabled", propValue, NULL)) {
-        prop_playback_enabled = atoi(propValue) || !strncmp("true", propValue, 4);
-    }
-
-    if(property_get("voice.record.conc.disabled", propValue, NULL)) {
-        prop_rec_enabled = atoi(propValue) || !strncmp("true", propValue, 4);
-    }
-
-    if(property_get("voice.voip.conc.disabled", propValue, NULL)) {
-        prop_voip_enabled = atoi(propValue) || !strncmp("true", propValue, 4);
-    }
-
+    bool prop_playback_enabled = !property_get_bool("voice.playback.conc.disabled", false);
+    bool prop_rec_enabled = !property_get_bool("voice.record.conc.disabled", false);
+    bool prop_voip_enabled = !property_get_bool("voice.voip.conc.disabled", false);
     bool mode_in_call = (AUDIO_MODE_IN_CALL != oldState) && (AUDIO_MODE_IN_CALL == state);
     //query if it is a actual voice call initiated by telephony
     if (mode_in_call) {


### PR DESCRIPTION
* Settings some.feature.disabled=true should definitely NOT enable said
  feature.

Change-Id: I3b7adff164c6ef89046d5c99bfe0a74c56caec67