### PR TITLE
libmedia: Increase framecount in Track Offload

### DIFF
--- a/include/media/AudioTrack.h
+++ b/include/media/AudioTrack.h
@@ -690,7 +690,13 @@ protected:
             static bool decideTrackOffloadFromStreamType(const audio_stream_type_t sType);
 
             static bool decideTrackOffloadfromAttributes(const audio_attributes_t *pAttributes);
+
             void initializeTrackOffloadParams();
+
+            void setTrackOffloadParams(audio_output_flags_t flags);
+
+            void resetTrackOffloadParams();
+
     // Next 4 fields may be changed if IAudioTrack is re-created, but always != 0
 #ifdef QCOM_DIRECTTRACK
     sp<IDirectTrack>        mDirectTrack;


### PR DESCRIPTION
Track offloading requires higher framecount
to avoid underruns. Fix this, by increasing
the framecount to what the client has requested
for since the client need not start the track
till the requested framecount has been reached

CRs-Fixed: 880862
Change-Id: I1d5e6cb9cb57cdec021a846a4e5b6ea1b68c7271