### PR TITLE
audiopolicy: Never use low-latency audio for ringtones

### DIFF
--- a/services/audiopolicy/Android.mk
+++ b/services/audiopolicy/Android.mk
@@ -66,6 +66,10 @@ ifeq ($(TARGET_ENABLE_QC_AV_ENHANCEMENTS),true)
 common_cflags += -DENABLE_AV_ENHANCEMENTS
 endif
 
+ifeq ($(AUDIO_FEATURE_DEEP_BUFFER_RINGTONE),true)
+common_cflags += -DDEEP_BUFFER_RINGTONE
+endif
+
 endif
 
 

--- a/services/audiopolicy/AudioPolicyManager.cpp
+++ b/services/audiopolicy/AudioPolicyManager.cpp
@@ -1634,6 +1634,14 @@ audio_io_handle_t AudioPolicyManager::getOutputForDevice(
         flags = AUDIO_OUTPUT_FLAG_DEEP_BUFFER;
     }
 
+#ifdef DEEP_BUFFER_RINGTONE
+    // don't use low latency for ringtones as it could cause i/o starvation
+    // in usecases like camera where a device may be in thermal mitigation
+    if (stream == AUDIO_STREAM_RING) {
+        flags = AUDIO_OUTPUT_FLAG_DEEP_BUFFER;
+    }
+#endif
+
     sp<IOProfile> profile;
 
     // skip direct output selection if the request can obviously be attached to a mixed output


### PR DESCRIPTION
 * If a device is under heavy load or thermal mitigation, it's
   possible for the audio thread to starve the system of resources.
   This can result in the heads-up notification taking many seconds to
   appear, or potentially miss the call entirely.
 * Force deep-buffer for all ringtones if
   AUDIO_FEATURE_DEEP_BUFFER_RINGTONE is set during compilation.

CYNGNOS-969

Change-Id: I74a07850f0140697bb121328e170a7ac5a1f5e7a