### PR TITLE
audiopolicy: Fix the incall fix

### DIFF
--- a/services/audiopolicy/AudioPolicyManager.cpp
+++ b/services/audiopolicy/AudioPolicyManager.cpp
@@ -1413,6 +1413,15 @@ status_t AudioPolicyManager::getOutputForAttr(const audio_attributes_t *attr,
 #endif
 
     *stream = streamTypefromAttributesInt(&attributes);
+
+#ifdef DEEP_BUFFER_RINGTONE
+    // don't use low latency for ringtones as it could cause i/o starvation
+    // in usecases like camera where a device may be in thermal mitigation
+    if (attributes.usage == AUDIO_USAGE_NOTIFICATION_TELEPHONY_RINGTONE) {
+        flags = AUDIO_OUTPUT_FLAG_DEEP_BUFFER;
+    }
+#endif
+
     *output = getOutputForDevice(device, session, *stream,
                                  samplingRate, format, channelMask,
                                  flags, offloadInfo);
@@ -1633,14 +1642,6 @@ audio_io_handle_t AudioPolicyManager::getOutputForDevice(
         //use DEEP_BUFFER as default output for music stream type
         flags = AUDIO_OUTPUT_FLAG_DEEP_BUFFER;
     }
-
-#ifdef DEEP_BUFFER_RINGTONE
-    // don't use low latency for ringtones as it could cause i/o starvation
-    // in usecases like camera where a device may be in thermal mitigation
-    if (stream == AUDIO_STREAM_RING) {
-        flags = AUDIO_OUTPUT_FLAG_DEEP_BUFFER;
-    }
-#endif
 
     sp<IOProfile> profile;
 


### PR DESCRIPTION
 * Use audio attributes instead of stream type so this doesn't apply to
   other streams which should stay unchanged.

JALEBI-654

Change-Id: Ia1760134eb30594f2d7f399675f8d409549522c7