### PR TITLE
Fix integer overflow in time conversion

### DIFF
--- a/media/libstagefright/MPEG4Writer.cpp
+++ b/media/libstagefright/MPEG4Writer.cpp
@@ -964,7 +964,11 @@ uint32_t MPEG4Writer::getMpeg4Time() {
     // MP4 file uses time counting seconds since midnight, Jan. 1, 1904
     // while time function returns Unix epoch values which starts
     // at 1970-01-01. Lets add the number of seconds between them
-    uint32_t mpeg4Time = now + (66 * 365 + 17) * (24 * 60 * 60);
+    static const uint32_t delta = (66 * 365 + 17) * (24 * 60 * 60);
+    if (now < 0 || uint32_t(now) > UINT32_MAX - delta) {
+        return 0;
+    }
+    uint32_t mpeg4Time = uint32_t(now) + delta;
     return mpeg4Time;
 }
 


### PR DESCRIPTION
Converting unix epoch time to mpeg4 time requires adding over 2B seconds,
which caused an overflow in a calculation involving time_t, which is signed.

Bug: 23574783
Change-Id: I21bacc9f5a422091f3c903fb8cf1c760fc078953