### PR TITLE
Revert "Revert "Revert "Enable -Os back to audioflinger"""

### DIFF
--- a/services/audioflinger/Android.mk
+++ b/services/audioflinger/Android.mk
@@ -93,8 +93,6 @@ endif
 endif
 #QTI Resampler
 
-LOCAL_CFLAGS += -Os
-
 LOCAL_MODULE:= libaudioflinger
 LOCAL_32_BIT_ONLY := true
 


### PR DESCRIPTION
This is not needed anymore

This reverts commit 733d67bd1fe00c7e7696601ae736fe74310fec11.