### PR TITLE
Fix setTorchMode support for the old HAL version

### DIFF
--- a/services/camera/libcameraservice/CameraFlashlight.cpp
+++ b/services/camera/libcameraservice/CameraFlashlight.cpp
@@ -882,6 +882,7 @@ status_t CameraHardwareInterfaceFlashControl::disconnectCameraDevice() {
     }
     mDevice->setPreviewWindow(NULL);
     mDevice->release();
+    mDevice = NULL;
 
     return OK;
 }


### PR DESCRIPTION
CameraHardwareInterfaceFlashControl class calls disconnectCameraDevice
when torch is disabled. This closes connection to the camera module,
but mDevice instance is kept and variable is non-NULL which will
prevent connection next time torch is going to be enabled.

Change-Id: Icb1ffb07f05256afd92821f0f4908cda5332c05b
